### PR TITLE
Update API compatibility for the Ballerina 2201.7.2 lang version

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "soap"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Ballerina"]
 keywords = ["soap"]
 repository = "https://github.com/ballerina-platform/module-ballerina-soap"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,10 +1,10 @@
 [package]
 org = "ballerina"
 name = "soap"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Ballerina"]
 keywords = ["soap"]
 repository = "https://github.com/ballerina-platform/module-ballerina-soap"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.5.0"
+distribution = "2201.7.2"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -203,17 +203,6 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
-name = "lang.xml"
-version = "0.0.0"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
-]
-modules = [
-	{org = "ballerina", packageName = "lang.xml", moduleName = "lang.xml"}
-]
-
-[[package]]
-org = "ballerina"
 name = "log"
 version = "2.8.1"
 dependencies = [
@@ -272,7 +261,6 @@ name = "soap"
 version = "0.1.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
-	{org = "ballerina", name = "lang.xml"},
 	{org = "ballerina", name = "mime"},
 	{org = "ballerina", name = "test"}
 ]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -50,7 +50,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -61,7 +61,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.9.1"
+version = "2.9.3"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -98,6 +98,9 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
 ]
+modules = [
+	{org = "ballerina", packageName = "io", moduleName = "io"}
+]
 
 [[package]]
 org = "ballerina"
@@ -261,6 +264,7 @@ name = "soap"
 version = "0.1.1"
 dependencies = [
 	{org = "ballerina", name = "http"},
+	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "mime"},
 	{org = "ballerina", name = "test"}
 ]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -98,9 +98,6 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
 ]
-modules = [
-	{org = "ballerina", packageName = "io", moduleName = "io"}
-]
 
 [[package]]
 org = "ballerina"
@@ -264,7 +261,6 @@ name = "soap"
 version = "0.1.1"
 dependencies = [
 	{org = "ballerina", name = "http"},
-	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "mime"},
 	{org = "ballerina", name = "test"}
 ]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.7.0"
+distribution-version = "2201.7.2"
 
 [[package]]
 org = "ballerina"
@@ -258,7 +258,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "soap"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "mime"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -258,7 +258,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "soap"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "mime"},

--- a/ballerina/soap.bal
+++ b/ballerina/soap.bal
@@ -54,28 +54,28 @@ public isolated client class Client {
 
     # Sends SOAP request and expects a response.
     # ```ballerina
-    # xml|mime:Entity[] response = check soapClient->sendReceive(body, action);
+    # xml|mime:Entity[] response = check soapClient->sendReceive(body);
     # ```
     #
     # + body - SOAP request body as an `XML` or `mime:Entity[]` to work with SOAP attachments
     # + action - SOAP action as a `string`
     # + headers - SOAP headers as a `map<string|string[]>`
     # + return - If successful, returns the response. Else, returns an error
-    remote function sendReceive(xml|mime:Entity[] body, string action, map<string|string[]> headers = {}) returns xml|mime:Entity[]|Error {
+    remote function sendReceive(xml|mime:Entity[] body, string? action = (), map<string|string[]> headers = {})returns xml|mime:Entity[]|Error {
         return sendReceive(self.soapVersion, body, self.soapClient, action, headers);
     }
 
     # Fires and forgets requests. Sends the request without the possibility of any response from the
     # service (even an error).
     # ```ballerina
-    # check soapClient->sendOnly(body, action);
+    # check soapClient->sendOnly(body);
     # ```
     #
     # + body - SOAP request body as an `XML` or `mime:Entity[]` to work with SOAP attachments
     # + action - SOAP action as a `string`
     # + headers - SOAP headers as a `map<string|string[]>`
     # + return - If successful, returns `nil`. Else, returns an error
-    remote function sendOnly(xml|mime:Entity[] body, string action, map<string|string[]> headers = {}) returns Error? {
+    remote function sendOnly(xml|mime:Entity[] body, string? action = (), map<string|string[]> headers = {}) returns Error? {
         return sendOnly(self.soapVersion, body, self.soapClient, action, headers);
     }
 }

--- a/ballerina/soap.bal
+++ b/ballerina/soap.bal
@@ -29,8 +29,8 @@ public enum SoapVersion {
 #
 # + soapVersion - SOAP version
 public type ClientConfiguration record {|
-  *http:ClientConfiguration;
-  SoapVersion soapVersion = SOAP11;
+    *http:ClientConfiguration;
+    SoapVersion soapVersion = SOAP11;
 |};
 
 # Object for the basic SOAP client endpoint.
@@ -46,7 +46,7 @@ public isolated client class Client {
     public function init(string url, *ClientConfiguration config) returns Error? {
         self.soapVersion = config.soapVersion;
         do {
-	        self.soapClient = check new (url,retrieveHttpClientConfig(config));
+            self.soapClient = check new (url, retrieveHttpClientConfig(config));
         } on fail var err {
             return error Error("Failed to initialize soap client", err);
         }
@@ -54,24 +54,28 @@ public isolated client class Client {
 
     # Sends SOAP request and expects a response.
     # ```ballerina
-    # xml|mime:Entity[] response = check soapClient->sendReceive(body);
+    # xml|mime:Entity[] response = check soapClient->sendReceive(body, action);
     # ```
     #
     # + body - SOAP request body as an `XML` or `mime:Entity[]` to work with SOAP attachments
+    # + action - SOAP action as a `string`
+    # + headers - SOAP headers as a `map<string|string[]>`
     # + return - If successful, returns the response. Else, returns an error
-    remote function sendReceive(xml|mime:Entity[] body) returns xml|mime:Entity[]|Error {
-        return sendReceive(self.soapVersion, body, self.soapClient);
+    remote function sendReceive(xml|mime:Entity[] body, string action, map<string|string[]> headers = {}) returns xml|mime:Entity[]|Error {
+        return sendReceive(self.soapVersion, body, self.soapClient, action, headers);
     }
 
     # Fires and forgets requests. Sends the request without the possibility of any response from the
     # service (even an error).
     # ```ballerina
-    # check soapClient->sendOnly(body);
+    # check soapClient->sendOnly(body, action);
     # ```
     #
     # + body - SOAP request body as an `XML` or `mime:Entity[]` to work with SOAP attachments
+    # + action - SOAP action as a `string`
+    # + headers - SOAP headers as a `map<string|string[]>`
     # + return - If successful, returns `nil`. Else, returns an error
-    remote function sendOnly(xml|mime:Entity[] body) returns Error? {
-        return sendOnly(self.soapVersion, body, self.soapClient);
+    remote function sendOnly(xml|mime:Entity[] body, string action, map<string|string[]> headers = {}) returns Error? {
+        return sendOnly(self.soapVersion, body, self.soapClient, action, headers);
     }
 }

--- a/ballerina/soap.bal
+++ b/ballerina/soap.bal
@@ -61,7 +61,8 @@ public isolated client class Client {
     # + action - SOAP action as a `string`
     # + headers - SOAP headers as a `map<string|string[]>`
     # + return - If successful, returns the response. Else, returns an error
-    remote function sendReceive(xml|mime:Entity[] body, string? action = (), map<string|string[]> headers = {})returns xml|mime:Entity[]|Error {
+    remote function sendReceive(xml|mime:Entity[] body, string? action = (),
+                                map<string|string[]> headers = {})returns xml|mime:Entity[]|Error {
         return sendReceive(self.soapVersion, body, self.soapClient, action, headers);
     }
 
@@ -75,7 +76,8 @@ public isolated client class Client {
     # + action - SOAP action as a `string`
     # + headers - SOAP headers as a `map<string|string[]>`
     # + return - If successful, returns `nil`. Else, returns an error
-    remote function sendOnly(xml|mime:Entity[] body, string? action = (), map<string|string[]> headers = {}) returns Error? {
+    remote function sendOnly(xml|mime:Entity[] body, string? action = (),
+                             map<string|string[]> headers = {}) returns Error? {
         return sendOnly(self.soapVersion, body, self.soapClient, action, headers);
     }
 }

--- a/ballerina/soap_utils.bal
+++ b/ballerina/soap_utils.bal
@@ -15,96 +15,39 @@
 // under the License.
 
 import ballerina/http;
-import ballerina/lang.'xml as xmllib;
 import ballerina/mime;
 
-# Provides an empty SOAP envelope for the given SOAP version.
-#
-# + soapVersion - The SOAP version of the request
-# + return - XML with the empty SOAP envelope
-function createSoapEnvelop(SoapVersion soapVersion) returns xmllib:Element {
-    if soapVersion == SOAP11 {
-        return <xmllib:Element> xml `<soap:Envelope
-        xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
-        soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-                </soap:Envelope>`;
-    } else {
-        return <xmllib:Element> xml `<soap:Envelope
-        xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
-        soap:encodingStyle="http://www.w3.org/2003/05/soap-encoding">
-                </soap:Envelope>`;
-    }
-}
-
-# Provides the SOAP headers in the request as XML.
-#
-# + soapVersion - The SOAP version of the request
-# + return - XML with the empty SOAP header
-function createSoapHeader(SoapVersion soapVersion) returns xml {
-    xmllib:Element headersRoot;
-    if soapVersion == SOAP11 {
-        headersRoot = <xmllib:Element> xml `<soap:Header xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"></soap:Header>`;
-    } else {
-        headersRoot = <xmllib:Element> xml `<soap:Header xmlns:soap="http://www.w3.org/2003/05/soap-envelope"></soap:Header>`;
-    }
-    return headersRoot;
-}
-
-# Provides the SOAP body in the request as XML.
-#
-# + payload - The payload to be sent
-# + soapVersion - The SOAP version of the request
-# + return - XML with the SOAP body
-function createSoapBody(xml payload, SoapVersion soapVersion) returns xml {
-    xmllib:Element bodyRoot;
-    if soapVersion == SOAP11 {
-        bodyRoot = <xmllib:Element> xml `<soap:Body xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"></soap:Body>`;
-    } else {
-        bodyRoot = <xmllib:Element> xml `<soap:Body xmlns:soap="http://www.w3.org/2003/05/soap-envelope"></soap:Body>`;
-    }
-    bodyRoot.setChildren(payload);
-    return bodyRoot;
-}
-
-# Prepares a SOAP envelope with the XML to be sent.
+# Creates a SOAP Request as an `http:Request`
 #
 # + soapAction - SOAP action
 # + body - SOAP request body as an `XML` or `mime:Entity[]` to work with soap attachments
 # + soapVersion - The SOAP version of the request
-# + return - The SOAP Request sent as `http:Request` with the SOAP envelope
-function fillSoapEnvelope(SoapVersion soapVersion, xml | mime:Entity[] body, string? soapAction = ())
+# + headers - SOAP headers as a `map<string|string[]>`
+# + return - The SOAP Request sent as `http:Request`
+function createHttpRequest(SoapVersion soapVersion, xml|mime:Entity[] body, string soapAction, map<string|string[]> headers = {})
 returns http:Request {
-    xml soapPayload = createSoapHeader(soapVersion);
     http:Request req = new;
-    var requestPayload = body;
-    if requestPayload is xml {
-        xml bodyPayload = createSoapBody(requestPayload, soapVersion);
-        soapPayload = soapPayload + bodyPayload;
-
-        xmllib:Element soapEnv = createSoapEnvelop(soapVersion);
-        soapEnv.setChildren(soapPayload);
-        req.setXmlPayload(soapEnv);
+    if body is xml {
+        req.setXmlPayload(body);
     } else {
-        req.setBodyParts(requestPayload);
+        req.setBodyParts(body);
     }
     if soapVersion == SOAP11 {
         req.setHeader(mime:CONTENT_TYPE, mime:TEXT_XML);
-        if soapAction is string {
-            req.addHeader("SOAPAction", soapAction);
-        }
+        req.addHeader("SOAPAction", soapAction);
     } else {
-        if soapAction is string {
-            map<string> stringMap = {};
-            stringMap["action"] = "\"" + soapAction + "\"";
-            var mediaType = mime:getMediaType(mime:APPLICATION_SOAP_XML);
-            if mediaType is mime:MediaType {
-                mediaType.parameters = stringMap;
-                req.setHeader(mime:CONTENT_TYPE, mediaType.toString());
-            }
-        } else {
-            req.setHeader(mime:CONTENT_TYPE, mime:APPLICATION_SOAP_XML);
+        map<string> stringMap = {};
+        stringMap["action"] = "\"" + soapAction + "\"";
+        var mediaType = mime:getMediaType(mime:APPLICATION_SOAP_XML);
+        if mediaType is mime:MediaType {
+            mediaType.parameters = stringMap;
+            req.setHeader(mime:CONTENT_TYPE, mediaType.toString());
         }
     }
+    foreach string key in headers.keys() {
+        req.addHeader(key, headers[key].toBalString());
+    }
+    
     return req;
 }
 
@@ -113,42 +56,37 @@ returns http:Request {
 # + response - The request to be sent
 # + soapVersion - The SOAP version of the request
 # + return - The SOAP response created from the `http:Response` or the `error` object when reading the payload
-function createSoapResponse(http:Response response, SoapVersion soapVersion) returns xml | error {
+function createSoapResponse(http:Response response, SoapVersion soapVersion) returns xml|error {
     xml payload = check response.getXmlPayload();
     xmlns "http://schemas.xmlsoap.org/soap/envelope/" as soap11;
     xmlns "http://www.w3.org/2003/05/soap-envelope" as soap12;
 
-    xml soapResponsePayload;
-    if soapVersion == SOAP11 {
-        soapResponsePayload = payload/<soap11:Body>;
-    } else {
-        soapResponsePayload = payload/<soap12:Body>;
-    }
-    return soapResponsePayload;
+    return soapVersion == SOAP11 ? payload/<soap11:Body> : payload/<soap12:Body>;
 }
 
 string path = "";
 
-function sendReceive(SoapVersion soapVersion, xml|mime:Entity[] body, http:Client httpClient, string? soapAction = ()) returns xml|Error {
-    http:Request req = fillSoapEnvelope(soapVersion, body, soapAction = soapAction);
+function sendReceive(SoapVersion soapVersion, xml|mime:Entity[] body, http:Client httpClient, string soapAction, map<string|string[]> headers = {}) returns xml|Error {
+    http:Request req = createHttpRequest(soapVersion, body, soapAction, headers);
     http:Response response;
     do {
-	    response = check httpClient->post(path, req);
+        response = check httpClient->post(path, req);
     } on fail var err {
-    	return error Error("Failed to receive soap response", err);
+        return error Error("Failed to receive soap response", err);
     }
     do {
-	    return check createSoapResponse(response, soapVersion);
+        return check createSoapResponse(response, soapVersion);
     } on fail var err {
-    	return error Error("Failed to create soap response", err);
+        return error Error("Failed to create soap response", err);
     }
 }
-function sendOnly(SoapVersion soapVersion, xml|mime:Entity[] body, http:Client httpClient, string? soapAction = ()) returns Error? {
-    http:Request req = fillSoapEnvelope(SOAP11, body, soapAction = soapAction);
+
+function sendOnly(SoapVersion soapVersion, xml|mime:Entity[] body, http:Client httpClient, string soapAction, map<string|string[]> headers = {}) returns Error? {
+    http:Request req = createHttpRequest(SOAP11, body, soapAction, headers);
     do {
-	    http:Response _ = check httpClient->post(path, req);
+        http:Response _ = check httpClient->post(path, req);
     } on fail var err {
-    	return error Error("Failed to create soap response", err);
+        return error Error("Failed to create soap response", err);
     }
 }
 

--- a/ballerina/soap_utils.bal
+++ b/ballerina/soap_utils.bal
@@ -24,8 +24,8 @@ import ballerina/mime;
 # + soapVersion - The SOAP version of the request
 # + headers - SOAP headers as a `map<string|string[]>`
 # + return - The SOAP Request sent as `http:Request`
-function createHttpRequest(SoapVersion soapVersion, xml|mime:Entity[] body, string? soapAction, map<string|string[]> headers = {})
-returns http:Request {
+function createHttpRequest(SoapVersion soapVersion, xml|mime:Entity[] body,
+                           string? soapAction, map<string|string[]> headers = {}) returns http:Request {
     http:Request req = new;
     if body is xml {
         req.setXmlPayload(body);
@@ -53,7 +53,6 @@ returns http:Request {
     foreach string key in headers.keys() {
         req.addHeader(key, headers[key].toBalString());
     }
-    
     return req;
 }
 
@@ -72,7 +71,8 @@ function createSoapResponse(http:Response response, SoapVersion soapVersion) ret
 
 string path = "";
 
-function sendReceive(SoapVersion soapVersion, xml|mime:Entity[] body, http:Client httpClient, string? soapAction = (), map<string|string[]> headers = {}) returns xml|Error {
+function sendReceive(SoapVersion soapVersion, xml|mime:Entity[] body, http:Client httpClient,
+                     string? soapAction = (), map<string|string[]> headers = {}) returns xml|Error {
     http:Request req = createHttpRequest(soapVersion, body, soapAction, headers);
     http:Response response;
     do {
@@ -87,7 +87,8 @@ function sendReceive(SoapVersion soapVersion, xml|mime:Entity[] body, http:Clien
     }
 }
 
-function sendOnly(SoapVersion soapVersion, xml|mime:Entity[] body, http:Client httpClient, string? soapAction = (), map<string|string[]> headers = {}) returns Error? {
+function sendOnly(SoapVersion soapVersion, xml|mime:Entity[] body, http:Client httpClient,
+                  string? soapAction = (), map<string|string[]> headers = {}) returns Error? {
     http:Request req = createHttpRequest(SOAP11, body, soapAction, headers);
     do {
         http:Response _ = check httpClient->post(path, req);

--- a/ballerina/tests/basic_client_test.bal
+++ b/ballerina/tests/basic_client_test.bal
@@ -19,54 +19,120 @@ import ballerina/mime;
 
 @test:Config {}
 function testSendReceive11() returns error? {
-    Client soapClient = check new("http://ws.cdyne.com/phoneverify/phoneverify.asmx?wsdl");
+    Client soapClient = check new ("http://www.dneonline.com/calculator.asmx?WSDL");
 
-    xml body = xml `<quer:CheckPhoneNumber xmlns:quer="http://ws.cdyne.com/PhoneVerify/query">
-         <quer:PhoneNumber>18006785432</quer:PhoneNumber>
-         <quer:LicenseKey>0</quer:LicenseKey>
-      </quer:CheckPhoneNumber>`;
+    xml body = xml `<soap:Envelope
+                        xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+                        soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+                        <soap:Body>
+                          <quer:Add xmlns:quer="http://tempuri.org/">
+                            <quer:intA>2</quer:intA>
+                            <quer:intB>3</quer:intB>
+                          </quer:Add>
+                        </soap:Body>
+                    </soap:Envelope>`;
 
-    xml|mime:Entity[] response = check soapClient->sendReceive(body);
+    xml|mime:Entity[] response = check soapClient->sendReceive(body, "http://tempuri.org/Add");
 
-    xml expected = xml `<soap:Body xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><CheckPhoneNumberResponse xmlns="http://ws.cdyne.com/PhoneVerify/query"><CheckPhoneNumberResult><Company>Toll Free</Company><Valid>true</Valid><Use>Assigned to a code holder for normal use.</Use><State>TF</State><RC/><OCN/><OriginalNumber>18006785432</OriginalNumber><CleanNumber>8006785432</CleanNumber><SwitchName/><SwitchType/><Country>United States</Country><CLLI/><PrefixType>Landline</PrefixType><LATA/><sms>Landline</sms><Email/><AssignDate>Unknown</AssignDate><TelecomCity/><TelecomCounty/><TelecomState>TF</TelecomState><TelecomZip/><TimeZone/><Lat/><Long/><Wireless>false</Wireless><LRN/></CheckPhoneNumberResult></CheckPhoneNumberResponse></soap:Body>`;
+    xml expected = xml `<soap:Body xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><AddResponse xmlns="http://tempuri.org/"><AddResult>5</AddResult></AddResponse></soap:Body>`;
     test:assertEquals(response, expected);
 }
 
 @test:Config {}
 function testSendReceive12() returns error? {
-    Client soapClient = check new("http://ws.cdyne.com/phoneverify/phoneverify.asmx?wsdl", soapVersion = SOAP12);
+    Client soapClient = check new ("http://www.dneonline.com/calculator.asmx?WSDL", soapVersion = SOAP12);
 
-    xml body = xml `<quer:CheckPhoneNumber xmlns:quer="http://ws.cdyne.com/PhoneVerify/query">
-         <quer:PhoneNumber>18006785432</quer:PhoneNumber>
-         <quer:LicenseKey>0</quer:LicenseKey>
-      </quer:CheckPhoneNumber>`;
+    xml body = xml `<soap:Envelope
+                        xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
+                        soap:encodingStyle="http://www.w3.org/2003/05/soap-encoding">
+                        <soap:Body>
+                          <quer:Add xmlns:quer="http://tempuri.org/">
+                            <quer:intA>2</quer:intA>
+                            <quer:intB>3</quer:intB>
+                          </quer:Add>
+                        </soap:Body>
+                    </soap:Envelope>`;
 
-    xml|mime:Entity[] response = check soapClient->sendReceive(body);
+    xml|mime:Entity[] response = check soapClient->sendReceive(body, "http://tempuri.org/Add");
 
-    xml expected = xml `<soap:Body xmlns:soap="http://www.w3.org/2003/05/soap-envelope"><CheckPhoneNumberResponse xmlns="http://ws.cdyne.com/PhoneVerify/query"><CheckPhoneNumberResult><Company>Toll Free</Company><Valid>true</Valid><Use>Assigned to a code holder for normal use.</Use><State>TF</State><RC/><OCN/><OriginalNumber>18006785432</OriginalNumber><CleanNumber>8006785432</CleanNumber><SwitchName/><SwitchType/><Country>United States</Country><CLLI/><PrefixType>Landline</PrefixType><LATA/><sms>Landline</sms><Email/><AssignDate>Unknown</AssignDate><TelecomCity/><TelecomCounty/><TelecomState>TF</TelecomState><TelecomZip/><TimeZone/><Lat/><Long/><Wireless>false</Wireless><LRN/></CheckPhoneNumberResult></CheckPhoneNumberResponse></soap:Body>`;
+    xml expected = xml `<soap:Body xmlns:soap="http://www.w3.org/2003/05/soap-envelope"><AddResponse xmlns="http://tempuri.org/"><AddResult>5</AddResult></AddResponse></soap:Body>`;
     test:assertEquals(response, expected);
 }
 
 @test:Config {}
 function testSendOnly11() returns error? {
-    Client soapClient = check new("http://ws.cdyne.com/phoneverify/phoneverify.asmx?wsdl");
+    Client soapClient = check new ("http://www.dneonline.com/calculator.asmx?WSDL");
 
-    xml body = xml `<quer:CheckPhoneNumber xmlns:quer="http://ws.cdyne.com/PhoneVerify/query">
-         <quer:PhoneNumber>18006785432</quer:PhoneNumber>
-         <quer:LicenseKey>0</quer:LicenseKey>
-      </quer:CheckPhoneNumber>`;
+    xml body = xml `<soap:Envelope
+                        xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+                        soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+                        <soap:Body>
+                          <quer:Add xmlns:quer="http://tempuri.org/">
+                            <quer:intA>2</quer:intA>
+                            <quer:intB>3</quer:intB>
+                          </quer:Add>
+                        </soap:Body>
+                    </soap:Envelope>`;
 
-    _ = check soapClient->sendOnly(body);
+    _ = check soapClient->sendOnly(body, "http://tempuri.org/Add");
 }
 
 @test:Config {}
 function testSendOnly12() returns error? {
-    Client soapClient = check new("http://ws.cdyne.com/phoneverify/phoneverify.asmx?wsdl", soapVersion = SOAP12);
+    Client soapClient = check new ("http://www.dneonline.com/calculator.asmx?WSDL", soapVersion = SOAP12);
 
-    xml body = xml `<quer:CheckPhoneNumber xmlns:quer="http://ws.cdyne.com/PhoneVerify/query">
-         <quer:PhoneNumber>18006785432</quer:PhoneNumber>
-         <quer:LicenseKey>0</quer:LicenseKey>
-      </quer:CheckPhoneNumber>`;
+    xml body = xml `<soap:Envelope
+                        xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
+                        soap:encodingStyle="http://www.w3.org/2003/05/soap-encoding">
+                        <soap:Body>
+                          <quer:Add xmlns:quer="http://tempuri.org/">
+                            <quer:intA>2</quer:intA>
+                            <quer:intB>3</quer:intB>
+                          </quer:Add>
+                        </soap:Body>
+                    </soap:Envelope>`;
 
-    _ = check soapClient->sendOnly(body);
+    _ = check soapClient->sendOnly(body, "http://tempuri.org/Add");
+}
+
+@test:Config {}
+function testSendReceive11WithHeaders() returns error? {
+    Client soapClient = check new ("http://www.dneonline.com/calculator.asmx?WSDL");
+
+    xml body = xml `<soap:Envelope
+                        xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+                        soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+                        <soap:Body>
+                          <quer:Add xmlns:quer="http://tempuri.org/">
+                            <quer:intA>2</quer:intA>
+                            <quer:intB>3</quer:intB>
+                          </quer:Add>
+                        </soap:Body>
+                    </soap:Envelope>`;
+
+    xml|mime:Entity[] response = check soapClient->sendReceive(body, "http://tempuri.org/Add", {foo: ["bar1", "bar2"]});
+
+    xml expected = xml `<soap:Body xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><AddResponse xmlns="http://tempuri.org/"><AddResult>5</AddResult></AddResponse></soap:Body>`;
+    test:assertEquals(response, expected);
+}
+
+@test:Config {}
+function testSendReceive12WithHeaders() returns error? {
+    Client soapClient = check new ("http://www.dneonline.com/calculator.asmx?WSDL", soapVersion = SOAP12);
+
+    xml body = xml `<soap:Envelope
+                        xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
+                        soap:encodingStyle="http://www.w3.org/2003/05/soap-encoding">
+                        <soap:Body>
+                          <quer:Add xmlns:quer="http://tempuri.org/">
+                            <quer:intA>2</quer:intA>
+                            <quer:intB>3</quer:intB>
+                          </quer:Add>
+                        </soap:Body>
+                    </soap:Envelope>`;
+
+    xml|mime:Entity[] response = check soapClient->sendReceive(body, "http://tempuri.org/Add", {foo: ["bar1", "bar2"]});
+
+    xml expected = xml `<soap:Body xmlns:soap="http://www.w3.org/2003/05/soap-envelope"><AddResponse xmlns="http://tempuri.org/"><AddResult>5</AddResult></AddResponse></soap:Body>`;
+    test:assertEquals(response, expected);
 }

--- a/ballerina/tests/basic_client_test.bal
+++ b/ballerina/tests/basic_client_test.bal
@@ -136,3 +136,62 @@ function testSendReceive12WithHeaders() returns error? {
     xml expected = xml `<soap:Body xmlns:soap="http://www.w3.org/2003/05/soap-envelope"><AddResponse xmlns="http://tempuri.org/"><AddResult>5</AddResult></AddResponse></soap:Body>`;
     test:assertEquals(response, expected);
 }
+
+@test:Config {}
+function testSendReceive12WithoutSoapAction() returns error? {
+    Client soapClient = check new ("http://www.dneonline.com/calculator.asmx?WSDL", soapVersion = SOAP12);
+
+    xml body = xml `<soap:Envelope
+                        xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
+                        soap:encodingStyle="http://www.w3.org/2003/05/soap-encoding">
+                        <soap:Body>
+                          <quer:Add xmlns:quer="http://tempuri.org/">
+                            <quer:intA>2</quer:intA>
+                            <quer:intB>3</quer:intB>
+                          </quer:Add>
+                        </soap:Body>
+                    </soap:Envelope>`;
+
+    xml|mime:Entity[] response = check soapClient->sendReceive(body);
+
+    xml expected = xml `<soap:Body xmlns:soap="http://www.w3.org/2003/05/soap-envelope"><AddResponse xmlns="http://tempuri.org/"><AddResult>5</AddResult></AddResponse></soap:Body>`;
+    test:assertEquals(response, expected);
+}
+
+@test:Config {}
+function testSendOnly12WithoutSoapAction() returns error? {
+    Client soapClient = check new ("http://www.dneonline.com/calculator.asmx?WSDL", soapVersion = SOAP12);
+
+    xml body = xml `<soap:Envelope
+                        xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
+                        soap:encodingStyle="http://www.w3.org/2003/05/soap-encoding">
+                        <soap:Body>
+                          <quer:Add xmlns:quer="http://tempuri.org/">
+                            <quer:intA>2</quer:intA>
+                            <quer:intB>3</quer:intB>
+                          </quer:Add>
+                        </soap:Body>
+                    </soap:Envelope>`;
+
+    _ = check soapClient->sendOnly(body);
+}
+
+@test:Config {}
+function testSendReceive12IncludingHeadersWithoutSoapAction() returns error? {
+    Client soapClient = check new ("http://www.dneonline.com/calculator.asmx?WSDL", soapVersion = SOAP12);
+
+    xml body = xml `<soap:Envelope
+                        xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
+                        soap:encodingStyle="http://www.w3.org/2003/05/soap-encoding">
+                        <soap:Body>
+                          <quer:Add xmlns:quer="http://tempuri.org/">
+                            <quer:intA>2</quer:intA>
+                            <quer:intB>3</quer:intB>
+                          </quer:Add>
+                        </soap:Body>
+                    </soap:Envelope>`;
+
+    xml|mime:Entity[] response = check soapClient->sendReceive(body, (), {foo: ["bar1", "bar2"]});
+    xml expected = xml `<soap:Body xmlns:soap="http://www.w3.org/2003/05/soap-envelope"><AddResponse xmlns="http://tempuri.org/"><AddResult>5</AddResult></AddResponse></soap:Body>`;
+    test:assertEquals(response, expected);
+}

--- a/ballerina/tests/basic_client_test.bal
+++ b/ballerina/tests/basic_client_test.bal
@@ -110,7 +110,8 @@ function testSendReceive11WithHeaders() returns error? {
                         </soap:Body>
                     </soap:Envelope>`;
 
-    xml|mime:Entity[] response = check soapClient->sendReceive(body, "http://tempuri.org/Add", {foo: ["bar1", "bar2"]});
+    xml|mime:Entity[] response = check soapClient->sendReceive(body, "http://tempuri.org/Add",
+                                                               {foo: ["bar1", "bar2"]});
 
     xml expected = xml `<soap:Body xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><AddResponse xmlns="http://tempuri.org/"><AddResult>5</AddResult></AddResponse></soap:Body>`;
     test:assertEquals(response, expected);
@@ -131,7 +132,8 @@ function testSendReceive12WithHeaders() returns error? {
                         </soap:Body>
                     </soap:Envelope>`;
 
-    xml|mime:Entity[] response = check soapClient->sendReceive(body, "http://tempuri.org/Add", {foo: ["bar1", "bar2"]});
+    xml|mime:Entity[] response = check soapClient->sendReceive(body, "http://tempuri.org/Add",
+                                                               {foo: ["bar1", "bar2"]});
 
     xml expected = xml `<soap:Body xmlns:soap="http://www.w3.org/2003/05/soap-envelope"><AddResponse xmlns="http://tempuri.org/"><AddResult>5</AddResult></AddResponse></soap:Body>`;
     test:assertEquals(response, expected);

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,4 +7,4 @@ keywords = ["soap"]
 repository = "https://github.com/ballerina-platform/module-ballerina-soap"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.5.0"
+distribution = "2201.7.2"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
-version=0.1.1-SNAPSHOT
+version=0.2.0-SNAPSHOT
 
 checkstylePluginVersion=8.18
 spotbugsPluginVersion=4.5.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
-version=0.1.0
+version=0.1.1-SNAPSHOT
 
 checkstylePluginVersion=8.18
 spotbugsPluginVersion=4.5.1
@@ -9,7 +9,7 @@ downloadPluginVersion=4.0.4
 releasePluginVersion=2.6.0
 ballerinaGradlePluginVersion=1.0.0
 
-ballerinaLangVersion=2201.7.0
+ballerinaLangVersion=2201.7.2
 
 #stdlib dependencies
 stdlibIoVersion=1.5.0


### PR DESCRIPTION
## Purpose

This is to enhance the SOAP request functionality by adding support for the SOAP action parameter in SOAP requests. Previously, SOAP action headers were not required for SOAP requests, but now it is fixed.

Now, the APIs can be used in the following ways:

```ballerina
xml|mime:Entity[] response = check soapClient->sendReceive(body);
```
and
```ballerina
xml|mime:Entity[] response = check soapClient->sendReceive(body, action);
```
