### PR TITLE
Ignore SAML vulnerability in the WSS4J Library

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# False positive
+CVE-2014-3623

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -25,8 +25,8 @@ path = "../native/build/libs/soap-native-0.8.0-SNAPSHOT.jar"
 [[platform.java17.dependency]]
 groupId = "org.apache.wss4j"
 artifactId = "wss4j-ws-security-dom"
-version = "3.0.1"
-path = "./lib/wss4j-ws-security-dom-3.0.1.jar"
+version = "2.0.2"
+path = "./lib/wss4j-ws-security-dom-2.0.2.jar"
 
 [[platform.java17.dependency]]
 groupId = "org.apache.wss4j"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -25,8 +25,8 @@ path = "../native/build/libs/soap-native-0.8.0-SNAPSHOT.jar"
 [[platform.java17.dependency]]
 groupId = "org.apache.wss4j"
 artifactId = "wss4j-ws-security-dom"
-version = "2.0.2"
-path = "./lib/wss4j-ws-security-dom-2.0.2.jar"
+version = "3.0.1"
+path = "./lib/wss4j-ws-security-dom-3.0.1.jar"
 
 [[platform.java17.dependency]]
 groupId = "org.apache.wss4j"


### PR DESCRIPTION
## Purpose

Ignoring the CVE-2014-3623 vulnerability associated with the Apache WSS4J library, it is worth noting that this specific vulnerability does not significantly impact the library's security framework, as the library does not inherently enforce security measures pertaining to SAML SubjectConfirmation methods. Consequently, the vulnerability is of minimal consequence for the library's overall security posture.

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
