### PR TITLE
Fix `action` not set in the 'content-type' header in SOAP 1.2 

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "soap"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Ballerina"]
 export=["soap", "soap.soap11", "soap.soap12"]
 keywords = ["soap"]
@@ -19,8 +19,8 @@ graalvmCompatible = true
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "soap-native"
-version = "0.9.0"
-path = "../native/build/libs/soap-native-0.9.0.jar"
+version = "0.9.1"
+path = "../native/build/libs/soap-native-0.9.1-SNAPSHOT.jar"
 
 [[platform.java17.dependency]]
 groupId = "org.apache.wss4j"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "soap"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Ballerina"]
 export=["soap", "soap.soap11", "soap.soap12"]
 keywords = ["soap"]
@@ -19,8 +19,8 @@ graalvmCompatible = true
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "soap-native"
-version = "0.9.1"
-path = "../native/build/libs/soap-native-0.9.1-SNAPSHOT.jar"
+version = "0.10.0"
+path = "../native/build/libs/soap-native-0.10.0-SNAPSHOT.jar"
 
 [[platform.java17.dependency]]
 groupId = "org.apache.wss4j"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -64,7 +64,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.1"
+version = "2.10.4"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -269,7 +269,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "soap"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "http"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -269,7 +269,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "soap"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "http"},

--- a/ballerina/modules/soap12/tests/http_soap_service.bal
+++ b/ballerina/modules/soap12/tests/http_soap_service.bal
@@ -50,7 +50,7 @@ service / on new http:Listener(9090) {
 
     resource function post getActionPayload(http:Request request) returns http:Response|error {
         string[] headers = check request.getHeaders(mime:CONTENT_TYPE);
-        mime:MediaType mediaHeader = check mime:getMediaType(headers[1]);
+        mime:MediaType mediaHeader = check mime:getMediaType(headers[0]);
         map<string> actionMap = mediaHeader.parameters;
         string action = actionMap.get("action");
         if action == "http://tempuri.org/Add" {

--- a/ballerina/modules/soap12/tests/http_soap_service.bal
+++ b/ballerina/modules/soap12/tests/http_soap_service.bal
@@ -24,7 +24,7 @@ const crypto:KeyStore serverKeyStore = {
     password: KEY_PASSWORD
 };
 crypto:PrivateKey serverPrivateKey = check crypto:decodeRsaPrivateKeyFromKeyStore(serverKeyStore, KEY_ALIAS,
-                                                                                KEY_PASSWORD);
+                                                                                  KEY_PASSWORD);
 crypto:PublicKey serverPublicKey = check crypto:decodeRsaPublicKeyFromTrustStore(serverKeyStore, KEY_ALIAS);
 
 service / on new http:Listener(9090) {
@@ -50,7 +50,7 @@ service / on new http:Listener(9090) {
 
     resource function post getActionPayload(http:Request request) returns http:Response|error {
         string[] headers = check request.getHeaders(mime:CONTENT_TYPE);
-        mime:MediaType mediaHeader = check mime:getMediaType(headers[1]);
+        mime:MediaType mediaHeader = check mime:getMediaType(headers[0]);
         map<string> actionMap = mediaHeader.parameters;
         string action = actionMap.get("action");
         if action == "http://tempuri.org/Add" {

--- a/ballerina/modules/soap12/tests/http_soap_service.bal
+++ b/ballerina/modules/soap12/tests/http_soap_service.bal
@@ -50,7 +50,7 @@ service / on new http:Listener(9090) {
 
     resource function post getActionPayload(http:Request request) returns http:Response|error {
         string[] headers = check request.getHeaders(mime:CONTENT_TYPE);
-        mime:MediaType mediaHeader = check mime:getMediaType(headers[0]);
+        mime:MediaType mediaHeader = check mime:getMediaType(headers[1]);
         map<string> actionMap = mediaHeader.parameters;
         string action = actionMap.get("action");
         if action == "http://tempuri.org/Add" {

--- a/ballerina/modules/soap12/tests/http_soap_service.bal
+++ b/ballerina/modules/soap12/tests/http_soap_service.bal
@@ -48,6 +48,20 @@ service / on new http:Listener(9090) {
         return response;
     }
 
+    resource function post getActionPayload(http:Request request) returns http:Response|error {
+        string[] headers = check request.getHeaders(mime:CONTENT_TYPE);
+        mime:MediaType mediaHeader = check mime:getMediaType(headers[1]);
+        map<string> actionMap = mediaHeader.parameters;
+        string action = actionMap.get("action");
+        if action == "http://tempuri.org/Add" {
+            xml payload = check request.getXmlPayload();
+            http:Response response = new;
+            response.setPayload(payload);
+            return response;
+        }
+        return error("Invalid action is found");
+    }
+
     resource function post getSamePayload(http:Request request) returns http:Response|error {
         xml payload = check request.getXmlPayload();
         http:Response response = new;

--- a/ballerina/modules/soap12/tests/soap12_client_test.bal
+++ b/ballerina/modules/soap12/tests/soap12_client_test.bal
@@ -88,7 +88,7 @@ function testSendOnlyError12() returns error? {
 }
 
 @test:Config {
-    groups: ["soap12", "send_receive", "ww"]
+    groups: ["soap12", "send_receive"]
 }
 function testSendReceive12WithAction() returns error? {
     Client soapClient = check new ("http://localhost:9090");

--- a/ballerina/modules/soap12/tests/soap12_client_test.bal
+++ b/ballerina/modules/soap12/tests/soap12_client_test.bal
@@ -121,7 +121,7 @@ function testSendReceive12() returns error? {
 }
 
 @test:Config {
-    groups: ["soap12", "send_receive"]
+    groups: ["soap12", "send_receive", "mime"]
 }
 function testSendReceive12Mime() returns error? {
     Client soapClient = check new ("http://localhost:9090");
@@ -485,7 +485,7 @@ function testSoapReceiveWithSymmetricBindingAndOutboundConfig() returns error? {
         }
     );
     xml body = xml `<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" soap:encodingStyle="http://www.w3.org/2003/05/soap-encoding/"><soap:Body><quer:Add xmlns:quer="http://tempuri.org/"><quer:intA>2</quer:intA><quer:intB>3</quer:intB></quer:Add></soap:Body></soap:Envelope>`;
-    xml|mime:Entity[] response = check soapClient->sendReceive(body, "http://tempuri.org/Add", path = "/getSamePayload");
+    xml response = check soapClient->sendReceive(body, "http://tempuri.org/Add", path = "/getSamePayload");
     return soap:assertSymmetricBinding(response.toString(), string `<soap:Body><quer:Add xmlns:quer="http://tempuri.org/"><quer:intA>2</quer:intA><quer:intB>3</quer:intB></quer:Add></soap:Body>`);
 }
 
@@ -511,7 +511,7 @@ function testSendReceiveWithAsymmetricBindingAndOutboundConfig() returns error? 
     );
 
     xml body = xml `<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><soap:Body><quer:Add xmlns:quer="http://tempuri.org/"><quer:intA>2</quer:intA><quer:intB>3</quer:intB></quer:Add></soap:Body></soap:Envelope>`;
-    xml|mime:Entity[] response = check soapClient->sendReceive(body, "http://tempuri.org/Add", path = "/getSecuredPayload");
+    xml response = check soapClient->sendReceive(body, "http://tempuri.org/Add", path = "/getSecuredPayload");
     return soap:assertSymmetricBinding(response.toString(), string `<soap:Body><quer:Add xmlns:quer="http://tempuri.org/"><quer:intA>2</quer:intA><quer:intB>3</quer:intB></quer:Add></soap:Body>`);
 }
 

--- a/ballerina/modules/soap12/tests/soap12_client_test.bal
+++ b/ballerina/modules/soap12/tests/soap12_client_test.bal
@@ -88,6 +88,18 @@ function testSendOnlyError12() returns error? {
 }
 
 @test:Config {
+    groups: ["soap12", "send_receive", "ww"]
+}
+function testSendReceive12WithAction() returns error? {
+    Client soapClient = check new ("http://localhost:9090");
+    xml body = xml `<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" soap:encodingStyle="http://www.w3.org/2003/05/soap-encoding/"><soap:Body><quer:Add xmlns:quer="http://tempuri.org/"><quer:intA>2</quer:intA><quer:intB>3</quer:intB></quer:Add></soap:Body></soap:Envelope>`;
+
+    xml response = check soapClient->sendReceive(body, "http://tempuri.org/Add", path = "/getActionPayload");
+    xml expected = xml `<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" soap:encodingStyle="http://www.w3.org/2003/05/soap-encoding/"><soap:Body><quer:Add xmlns:quer="http://tempuri.org/"><quer:intA>2</quer:intA><quer:intB>3</quer:intB></quer:Add></soap:Body></soap:Envelope>`;
+    test:assertEquals(response, expected);
+}
+
+@test:Config {
     groups: ["soap12", "send_receive"]
 }
 function testSendReceive12() returns error? {
@@ -102,7 +114,7 @@ function testSendReceive12() returns error? {
                       </quer:Add>
                     </soap:Body>
                 </soap:Envelope>`;
-    xml response = check soapClient->sendReceive(body, "http://tempuri.org/Add");
+    xml response = check soapClient->sendReceive(body);
 
     xml expected = xml `<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><AddResponse xmlns="http://tempuri.org/"><AddResult>5</AddResult></AddResponse></soap:Body></soap:Envelope>`;
     test:assertEquals(response, expected);
@@ -203,31 +215,7 @@ function testSendReceive12WithHeaders() returns error? {
 
     Client soapClient = check new ("http://www.dneonline.com/calculator.asmx?WSDL");
 
-    xml response = check soapClient->sendReceive(body, "http://tempuri.org/Add",
-                                                                    {foo: ["bar1", "bar2"]});
-
-    xml expected = xml `<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><AddResponse xmlns="http://tempuri.org/"><AddResult>5</AddResult></AddResponse></soap:Body></soap:Envelope>`;
-    test:assertEquals(response, expected);
-}
-
-@test:Config {
-    groups: ["soap12", "send_receive"]
-}
-function testSendReceive12WithoutSoapAction() returns error? {
-    xml body = xml `<soap:Envelope
-                        xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
-                        soap:encodingStyle="http://www.w3.org/2003/05/soap-encoding">
-                        <soap:Body>
-                          <quer:Add xmlns:quer="http://tempuri.org/">
-                            <quer:intA>2</quer:intA>
-                            <quer:intB>3</quer:intB>
-                          </quer:Add>
-                        </soap:Body>
-                    </soap:Envelope>`;
-
-    Client soapClient = check new ("http://www.dneonline.com/calculator.asmx?WSDL");
-
-    xml response = check soapClient->sendReceive(body);
+    xml response = check soapClient->sendReceive(body, headers = {foo: ["bar1", "bar2"]});
 
     xml expected = xml `<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><AddResponse xmlns="http://tempuri.org/"><AddResult>5</AddResult></AddResponse></soap:Body></soap:Envelope>`;
     test:assertEquals(response, expected);
@@ -251,28 +239,6 @@ function testSendOnly12WithoutSoapAction() returns error? {
     Client soapClient = check new ("http://www.dneonline.com/calculator.asmx?WSDL");
 
     check soapClient->sendOnly(body);
-}
-
-@test:Config {
-    groups: ["soap12", "send_receive"]
-}
-function testSendReceive12IncludingHeadersWithoutSoapAction() returns error? {
-    xml body = xml `<soap:Envelope
-                        xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
-                        soap:encodingStyle="http://www.w3.org/2003/05/soap-encoding">
-                        <soap:Body>
-                          <quer:Add xmlns:quer="http://tempuri.org/">
-                            <quer:intA>2</quer:intA>
-                            <quer:intB>3</quer:intB>
-                          </quer:Add>
-                        </soap:Body>
-                    </soap:Envelope>`;
-
-    Client soapClient = check new ("http://www.dneonline.com/calculator.asmx?WSDL");
-
-    xml response = check soapClient->sendReceive(body, (), {foo: ["bar1", "bar2"]});
-    xml expected = xml `<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><AddResponse xmlns="http://tempuri.org/"><AddResult>5</AddResult></AddResponse></soap:Body></soap:Envelope>`;
-    test:assertEquals(response, expected);
 }
 
 @test:Config {
@@ -340,7 +306,7 @@ function testSendReceiveWithTimestampTokenSecurity() returns error? {
                           </quer:Add>
                         </soap:Body>
                     </soap:Envelope>`;
-    xml response = check soapClient->sendReceive(body, "http://tempuri.org/Add");
+    xml response = check soapClient->sendReceive(body);
     xml expected = xml `<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><soap:Fault><soap:Code><soap:Value>soap:MustUnderstand</soap:Value></soap:Code><soap:Reason><soap:Text xml:lang="en">System.Web.Services.Protocols.SoapHeaderException: SOAP header Security was not understood.
    at System.Web.Services.Protocols.SoapHeaderHandling.SetHeaderMembers(SoapHeaderCollection headers, Object target, SoapHeaderMapping[] mappings, SoapHeaderDirection direction, Boolean client)
    at System.Web.Services.Protocols.SoapServerProtocol.CreateServerInstance()
@@ -374,7 +340,7 @@ function testSendReceiveWithUsernameTokenSecurity() returns error? {
                           </quer:Add>
                         </soap:Body>
                     </soap:Envelope>`;
-    xml response = check soapClient->sendReceive(body, "http://tempuri.org/Add");
+    xml response = check soapClient->sendReceive(body);
     xml expected = xml `<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><soap:Fault><soap:Code><soap:Value>soap:MustUnderstand</soap:Value></soap:Code><soap:Reason><soap:Text xml:lang="en">System.Web.Services.Protocols.SoapHeaderException: SOAP header Security was not understood.
    at System.Web.Services.Protocols.SoapHeaderHandling.SetHeaderMembers(SoapHeaderCollection headers, Object target, SoapHeaderMapping[] mappings, SoapHeaderDirection direction, Boolean client)
    at System.Web.Services.Protocols.SoapServerProtocol.CreateServerInstance()
@@ -421,12 +387,13 @@ function testSendReceiveWithAsymmetricBindingSecurity() returns error? {
                           </quer:Add>
                         </soap:Body>
                     </soap:Envelope>`;
-    xml response = check soapClient->sendReceive(body, "http://tempuri.org/Add");
-    xml expected = xml `<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><soap:Fault><soap:Code><soap:Value>soap:MustUnderstand</soap:Value></soap:Code><soap:Reason><soap:Text xml:lang="en">System.Web.Services.Protocols.SoapHeaderException: SOAP header Security was not understood.
-   at System.Web.Services.Protocols.SoapHeaderHandling.SetHeaderMembers(SoapHeaderCollection headers, Object target, SoapHeaderMapping[] mappings, SoapHeaderDirection direction, Boolean client)
-   at System.Web.Services.Protocols.SoapServerProtocol.CreateServerInstance()
-   at System.Web.Services.Protocols.WebServiceHandler.Invoke()
-   at System.Web.Services.Protocols.WebServiceHandler.CoreProcessRequest()</soap:Text></soap:Reason></soap:Fault></soap:Body></soap:Envelope>`;
+    xml response = check soapClient->sendReceive(body);
+    xml expected = xml `<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><soap:Fault><soap:Code><soap:Value>soap:Sender</soap:Value></soap:Code><soap:Reason><soap:Text xml:lang="en">System.Web.Services.Protocols.SoapException: Unable to handle request without a valid action parameter. Please supply a valid soap action.
+   at System.Web.Services.Protocols.Soap12ServerProtocolHelper.RouteRequest()
+   at System.Web.Services.Protocols.SoapServerProtocol.RouteRequest(SoapServerMessage message)
+   at System.Web.Services.Protocols.SoapServerProtocol.Initialize()
+   at System.Web.Services.Protocols.ServerProtocol.SetContext(Type type, HttpContext context, HttpRequest request, HttpResponse response)
+   at System.Web.Services.Protocols.ServerProtocolFactory.Create(Type type, HttpContext context, HttpRequest request, HttpResponse response, Boolean&amp; abortProcessing)</soap:Text></soap:Reason><soap:Detail/></soap:Fault></soap:Body></soap:Envelope>`;
 
     test:assertEquals(response.toString(), expected.toString());
 }
@@ -467,12 +434,13 @@ function testSendReceiveWithSymmetricBindingSecurity() returns error? {
                           </quer:Add>
                         </soap:Body>
                     </soap:Envelope>`;
-    xml response = check soapClient->sendReceive(body, "http://tempuri.org/Add");
-    xml expected = xml `<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><soap:Fault><soap:Code><soap:Value>soap:MustUnderstand</soap:Value></soap:Code><soap:Reason><soap:Text xml:lang="en">System.Web.Services.Protocols.SoapHeaderException: SOAP header Security was not understood.
-   at System.Web.Services.Protocols.SoapHeaderHandling.SetHeaderMembers(SoapHeaderCollection headers, Object target, SoapHeaderMapping[] mappings, SoapHeaderDirection direction, Boolean client)
-   at System.Web.Services.Protocols.SoapServerProtocol.CreateServerInstance()
-   at System.Web.Services.Protocols.WebServiceHandler.Invoke()
-   at System.Web.Services.Protocols.WebServiceHandler.CoreProcessRequest()</soap:Text></soap:Reason></soap:Fault></soap:Body></soap:Envelope>`;
+    xml response = check soapClient->sendReceive(body);
+    xml expected = xml `<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><soap:Fault><soap:Code><soap:Value>soap:Sender</soap:Value></soap:Code><soap:Reason><soap:Text xml:lang="en">System.Web.Services.Protocols.SoapException: Unable to handle request without a valid action parameter. Please supply a valid soap action.
+   at System.Web.Services.Protocols.Soap12ServerProtocolHelper.RouteRequest()
+   at System.Web.Services.Protocols.SoapServerProtocol.RouteRequest(SoapServerMessage message)
+   at System.Web.Services.Protocols.SoapServerProtocol.Initialize()
+   at System.Web.Services.Protocols.ServerProtocol.SetContext(Type type, HttpContext context, HttpRequest request, HttpResponse response)
+   at System.Web.Services.Protocols.ServerProtocolFactory.Create(Type type, HttpContext context, HttpRequest request, HttpResponse response, Boolean&amp; abortProcessing)</soap:Text></soap:Reason><soap:Detail/></soap:Fault></soap:Body></soap:Envelope>`;
     test:assertEquals(response.toString(), expected.toString());
 }
 

--- a/ballerina/soap_utils.bal
+++ b/ballerina/soap_utils.bal
@@ -152,12 +152,10 @@ isolated function createSoap12HttpRequest(xml|mime:Entity[] body, string? soapAc
     http:Request req = new;
     _ = body is xml ? req.setXmlPayload(body) : req.setBodyParts(body);
     if soapAction is string {
-        map<string> stringMap = {};
-        stringMap["action"] = "\"" + soapAction + "\"";
         var mediaType = mime:getMediaType(mime:APPLICATION_SOAP_XML);
         if mediaType is mime:MediaType {
-            mediaType.parameters = stringMap;
-            req.addHeader(mime:CONTENT_TYPE, mediaType.toString());
+            mediaType.parameters = {"action": string`"${soapAction}"`};
+            req.setHeader(mime:CONTENT_TYPE, mediaType.toString());
         }
     } else if body is xml {
         req.setHeader(mime:CONTENT_TYPE, mime:TEXT_XML);

--- a/ballerina/soap_utils.bal
+++ b/ballerina/soap_utils.bal
@@ -156,8 +156,6 @@ isolated function createSoap12HttpRequest(xml|mime:Entity[] body, string? soapAc
         req.setBodyParts(body);
     }
     if soapAction is string {
-        map<string> stringMap = {};
-        stringMap["action"] = "\"" + soapAction + "\"";
         mime:MediaType|mime:InvalidContentTypeError mediaType;
         if body is xml {
             mediaType = mime:getMediaType(mime:APPLICATION_SOAP_XML);

--- a/ballerina/soap_utils.bal
+++ b/ballerina/soap_utils.bal
@@ -154,15 +154,16 @@ isolated function createSoap12HttpRequest(xml|mime:Entity[] body, string? soapAc
     if soapAction is string {
         map<string> stringMap = {};
         stringMap["action"] = "\"" + soapAction + "\"";
-        var mediaType = mime:getMediaType(mime:APPLICATION_SOAP_XML);
+        mime:MediaType|mime:InvalidContentTypeError mediaType = body is xml
+            ? mime:getMediaType(mime:APPLICATION_SOAP_XML)
+            : mime:getMediaType(mime:MULTIPART_MIXED);
         if mediaType is mime:MediaType {
-            mediaType.parameters = {"action": string`"${soapAction}"`};
-            req.addHeader(mime:CONTENT_TYPE, mediaType.toString());
+            mediaType.parameters = {"action": string `"${soapAction}"`};
+            req.setHeader(mime:CONTENT_TYPE, mediaType.toString());
         }
-    } else if body is xml {
-        req.setHeader(mime:CONTENT_TYPE, mime:TEXT_XML);
     } else {
-        req.setHeader(mime:CONTENT_TYPE, mime:MULTIPART_MIXED);
+        _ = body is xml ? req.setHeader(mime:CONTENT_TYPE, mime:TEXT_XML)
+            : req.setHeader(mime:CONTENT_TYPE, mime:MULTIPART_MIXED);
     }
     foreach string key in headers.keys() {
         req.addHeader(key, headers[key].toBalString());

--- a/ballerina/soap_utils.bal
+++ b/ballerina/soap_utils.bal
@@ -152,10 +152,12 @@ isolated function createSoap12HttpRequest(xml|mime:Entity[] body, string? soapAc
     http:Request req = new;
     _ = body is xml ? req.setXmlPayload(body) : req.setBodyParts(body);
     if soapAction is string {
+        map<string> stringMap = {};
+        stringMap["action"] = "\"" + soapAction + "\"";
         var mediaType = mime:getMediaType(mime:APPLICATION_SOAP_XML);
         if mediaType is mime:MediaType {
             mediaType.parameters = {"action": string`"${soapAction}"`};
-            req.setHeader(mime:CONTENT_TYPE, mediaType.toString());
+            req.addHeader(mime:CONTENT_TYPE, mediaType.toString());
         }
     } else if body is xml {
         req.setHeader(mime:CONTENT_TYPE, mime:TEXT_XML);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
-version=0.9.1-SNAPSHOT
+version=0.10.0-SNAPSHOT
 
 checkstylePluginVersion=10.12.0
 spotbugsPluginVersion=5.0.14


### PR DESCRIPTION
## Purpose
Fixes: [#5842](https://github.com/ballerina-platform/ballerina-library/issues/5842)