### PR TITLE
Fix getting `NoSuchElement` exception when applying security policies

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "soap"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Ballerina"]
 export=["soap", "soap.soap11", "soap.soap12"]
 keywords = ["soap"]
@@ -19,8 +19,8 @@ graalvmCompatible = true
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "soap-native"
-version = "2.0.0"
-path = "../native/build/libs/soap-native-2.0.0.jar"
+version = "2.0.1"
+path = "../native/build/libs/soap-native-2.0.1-SNAPSHOT.jar"
 
 [[platform.java17.dependency]]
 groupId = "org.apache.wss4j"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -64,7 +64,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.12.0"
+version = "2.12.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -271,7 +271,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "soap"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "http"},

--- a/ballerina/modules/soap11/tests/soap11_client_test.bal
+++ b/ballerina/modules/soap11/tests/soap11_client_test.bal
@@ -387,7 +387,7 @@ function testSoapReceiveWithAsymmetricBindingAndInboundConfig() returns error? {
     xmlns "http://schemas.xmlsoap.org/soap/envelope/" as soap11;
     Client soapClient = check new ("http://localhost:9090",
         {
-            outboundSecurity: {
+            outboundSecurity: [{
                 signatureConfig: {
                     keystore: {
                         path: KEY_STORE_PATH_2,
@@ -408,6 +408,9 @@ function testSoapReceiveWithAsymmetricBindingAndInboundConfig() returns error? {
                     encryptionAlgorithm: wssec:AES_128
                 }
             },
+            {
+                timeToLive: 1
+            }],
             inboundSecurity: {
                 decryptKeystore: {
                     path: KEY_STORE_PATH_2,

--- a/ballerina/modules/soap12/tests/soap12_client_test.bal
+++ b/ballerina/modules/soap12/tests/soap12_client_test.bal
@@ -420,7 +420,7 @@ function testSoapReceiveWithAsymmetricBindingAndInboundConfig() returns error? {
     xmlns "http://www.w3.org/2003/05/soap-envelope" as soap11;
     Client soapClient = check new ("http://localhost:9091",
         {
-            outboundSecurity: {
+            outboundSecurity: [{
                 signatureConfig: {
                     keystore: {
                         path: KEY_STORE_PATH_2,
@@ -440,7 +440,9 @@ function testSoapReceiveWithAsymmetricBindingAndInboundConfig() returns error? {
                     publicKeyAlias: ALIAS,
                     encryptionAlgorithm: wssec:AES_128
                 }
-            },
+            }, {
+                timeToLive: 1
+            }],
             inboundSecurity: {
                 decryptKeystore: {
                     path: KEY_STORE_PATH_2,

--- a/ballerina/soap_utils.bal
+++ b/ballerina/soap_utils.bal
@@ -58,7 +58,7 @@ public isolated function applySecurityPolicies(wssec:OutboundSecurityConfig|wsse
     } else {
         xml securedEnvelope = envelope.clone();
         foreach wssec:OutboundSecurityConfig policy in security {
-            securedEnvelope = check applySecurityPolicies(policy, securedEnvelope);
+            securedEnvelope = check applySecurityPolicies(policy, securedEnvelope, soap12);
         }
         return securedEnvelope;
     }


### PR DESCRIPTION
## Purpose
When applying security policies in an array it returns noSuchElement exception due to the missing `soap12` parameter which determines the SOAP protocol.